### PR TITLE
Sync with pgBackRest v2.39.

### DIFF
--- a/pgbackrest-completion.sh
+++ b/pgbackrest-completion.sh
@@ -27,18 +27,24 @@ __pgbackrest_command_options_values() {
     echo ${command_options_values}
 }
 
-# The '--output' option is available for 2 commands ('repo-ls' and 'info') with the same values.
+# The '--output' option is available for 'repo-ls' and 'info' commands with the same values.
 # For 'repo-ls' command displayed additional information in the same format. 
-# To simplify the solution, the option values are specified directly.
-# If the values for different commands will be different, this code must be reviewed.
+# To simplify the solution and not write additional regexp, the option values are specified directly.
 __pgbackrest_command_options_values_output() {
     echo "text"$'\n'"json"
+}
+
+# The '--output' option is available for 'verify' command with another values.
+# As well as other formatting of the hint text.
+# When new commands with unique options list appear, refactoring will be required.
+__pgbackrest_command_options_values_output_verify() {
+    echo "none"$'\n'"text"
 }
 
 # The '--buffer-size' displays values in the user friendly format starting from pgBackRest v2.37.
 # In earlier versions, values in bytes will be substituted.
 # https://github.com/pgbackrest/pgbackrest/pull/1557
-__pgbackrest_command_options_values_buffer_size(){
+__pgbackrest_command_options_values_buffer_size() {
     local buffer_size_option_values
     # Regex for valid values like:
     #   16384,
@@ -150,8 +156,15 @@ _pgbackrest() {
                             COMPREPLY=($(compgen -W "$(__pgbackrest_stanza_values)" -- ${cur}))
                             return 0;;
                         --output)
-                            COMPREPLY=($(compgen -W "$(__pgbackrest_command_options_values_output)" -- ${cur}))
-                            return 0;;
+                            # Different values for the '--output' option depending on the command.
+                            case ${COMP_WORDS[1]} in
+                                verify)
+                                    COMPREPLY=($(compgen -W "$(__pgbackrest_command_options_values_output_verify)" -- ${cur}))
+                                    return 0;;
+                                *)
+                                    COMPREPLY=($(compgen -W "$(__pgbackrest_command_options_values_output)" -- ${cur}))
+                                    return 0;;
+                            esac;;
                         --buffer-size)
                             COMPREPLY=($(compgen -W "$(__pgbackrest_command_options_values_buffer_size)" -- ${cur}))
                             return 0;;
@@ -186,8 +199,14 @@ _pgbackrest() {
                             COMPREPLY=($(compgen -W "$(__pgbackrest_stanza_values)" -- ${cur}))
                             return 0;;
                         --output)
-                            COMPREPLY=($(compgen -W "$(__pgbackrest_command_options_values_output)" -- ${cur}))
-                            return 0;;
+                            case ${COMP_WORDS[1]} in
+                                verify)
+                                    COMPREPLY=($(compgen -W "$(__pgbackrest_command_options_values_output_verify)" -- ${cur}))
+                                    return 0;;
+                                *)
+                                    COMPREPLY=($(compgen -W "$(__pgbackrest_command_options_values_output)" -- ${cur}))
+                                    return 0;;
+                            esac;;
                         --buffer-size)
                             COMPREPLY=($(compgen -W "$(__pgbackrest_command_options_values_buffer_size)" -- ${cur}))
                             return 0;;

--- a/pgbackrest-completion.sh
+++ b/pgbackrest-completion.sh
@@ -61,6 +61,12 @@ __pgbackrest_command_options_values_buffer_size() {
     echo ${buffer_size_option_values[@]}
 }
 
+# The '--type' option for 'info' command has non-standard hint text formating for parsing.
+# If the number of commands with non-standard hint text formating will grow, refactoring will be required.
+__pgbackrest_command_options_values_type_info() {
+    echo "full"$'\n'"incr"$'\n'"diff"
+}
+
 # If no stanza - return empty string; nothing to complete.
 # May be some delays in getting stanza names.
 __pgbackrest_stanza_values() {
@@ -168,6 +174,17 @@ _pgbackrest() {
                         --buffer-size)
                             COMPREPLY=($(compgen -W "$(__pgbackrest_command_options_values_buffer_size)" -- ${cur}))
                             return 0;;
+                        --type)
+                            # Different values for the '--type' option depending on the command.
+                            case ${COMP_WORDS[1]} in
+                                info)
+                                    COMPREPLY=($(compgen -W "$(__pgbackrest_command_options_values_backup_types)" -- ${cur}))
+                                    return 0;;
+                                *)
+                                    # The usual completion for all other commands.
+                                    COMPREPLY=($(compgen -W "$(__pgbackrest_command_options_values)" -- ${cur}))
+                                    return 0;;
+                            esac;;
                         *)
                             if [[ ${prev} =~ ${arg_regex} ]]; then
                                 COMPREPLY=($(compgen -W "$(__pgbackrest_command_options_values)" -- ${cur}))
@@ -210,6 +227,15 @@ _pgbackrest() {
                         --buffer-size)
                             COMPREPLY=($(compgen -W "$(__pgbackrest_command_options_values_buffer_size)" -- ${cur}))
                             return 0;;
+                        --type)
+                            case ${COMP_WORDS[1]} in
+                                info)
+                                    COMPREPLY=($(compgen -W "$(__pgbackrest_command_options_values_backup_types)" -- ${cur}))
+                                    return 0;;
+                                *)
+                                    COMPREPLY=($(compgen -W "$(__pgbackrest_command_options_values)" -- ${cur}))
+                                    return 0;;
+                            esac;;
                         *)
                             if [[ ${prev} =~ ${arg_regex} ]]; then
                                 COMPREPLY=($(compgen -W "$(__pgbackrest_command_options_values)" -- ${cur}))


### PR DESCRIPTION
* Added completion for `--output` option for `verify` command.
* Added completion for `--type` option for `info` command.