### PR TITLE
Add completion of parameters depending on the specified --config* options.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2022 woblerr
+Copyright (c) 2020-2023 woblerr
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Also fixed issue with `--repo` for `repo-ls`/`repo-get` commands. When `--repo` flag was specified not last, it wan't used in completion.